### PR TITLE
Fix clang-tidy 21 lint warnings in conversions and filesystem

### DIFF
--- a/tue_serialization/include/tue/serialization/conversions.h
+++ b/tue_serialization/include/tue/serialization/conversions.h
@@ -1,12 +1,13 @@
 #ifndef TUE_SERIALIZATION_CONVERSIONS_H_
 #define TUE_SERIALIZATION_CONVERSIONS_H_
 
-#include <istream>
-#include <vector>
-
 #include "archive.h"
 #include "input_archive.h"
 #include "output_archive.h"
+
+#include <istream>
+#include <ostream>
+#include <vector>
 
 namespace tue
 {

--- a/tue_serialization/include/tue/serialization/filesystem.h
+++ b/tue_serialization/include/tue/serialization/filesystem.h
@@ -2,6 +2,7 @@
 #define TUE_SERIALIZATION_FILESYSTEM_H_
 
 #include <istream>
+#include <string>
 #include <vector>
 
 #include "archive.h"

--- a/tue_serialization/src/conversions.cpp
+++ b/tue_serialization/src/conversions.cpp
@@ -27,7 +27,7 @@ void convert(Archive& a, std::vector<unsigned char>& data)
 void convert(const Archive& a, std::ostream& out)
 {
     // Write the version to out
-    [[maybe_unused]] OutputArchive a_out(out);
+    [[maybe_unused]] const OutputArchive a_out(out);
 
     // Write data to out
     out << a.stream().rdbuf();

--- a/tue_serialization/src/conversions.cpp
+++ b/tue_serialization/src/conversions.cpp
@@ -27,7 +27,7 @@ void convert(Archive& a, std::vector<unsigned char>& data)
 void convert(const Archive& a, std::ostream& out)
 {
     // Write the version to out
-    const OutputArchive a_out(out);
+    [[maybe_unused]] OutputArchive a_out(out);
 
     // Write data to out
     out << a.stream().rdbuf();
@@ -60,11 +60,10 @@ void convert(std::istream& s, std::vector<unsigned char>& data, int d_offset)
 void convert(std::vector<unsigned char>& data, Archive& a)
 {
     // Read version (int)
-    const int version = 0;
-    std::memcpy(&a.version_, data.data(), sizeof(version));
+    std::memcpy(&a.version_, data.data(), sizeof(a.version_));
 
     // Read the rest
-    convert(data, a.stream(), sizeof(version));
+    convert(data, a.stream(), sizeof(a.version_));
 }
 
 // ----------------------------------------------------------------------------------------------------

--- a/tue_serialization/src/conversions.cpp
+++ b/tue_serialization/src/conversions.cpp
@@ -1,11 +1,14 @@
 #include "tue/serialization/conversions.h"
+#include "tue/serialization/archive.h"
 #include "tue/serialization/output_archive.h"
 
-#include <string.h> // memcpy
+#include <cstring> // std::memcpy
+#include <ios>
+#include <istream>
+#include <ostream>
+#include <vector>
 
-namespace tue
-{
-namespace serialization
+namespace tue::serialization
 {
 
 // ----------------------------------------------------------------------------------------------------
@@ -16,7 +19,7 @@ void convert(Archive& a, std::vector<unsigned char>& data)
     convert(a.stream(), data, sizeof(version));
 
     // Fill version bytes
-    memcpy(&data[0], (char*)&version, sizeof(version));
+    std::memcpy(data.data(), &version, sizeof(version));
 }
 
 // ----------------------------------------------------------------------------------------------------
@@ -24,7 +27,7 @@ void convert(Archive& a, std::vector<unsigned char>& data)
 void convert(const Archive& a, std::ostream& out)
 {
     // Write the version to out
-    OutputArchive a_out(out);
+    const OutputArchive a_out(out);
 
     // Write data to out
     out << a.stream().rdbuf();
@@ -45,11 +48,11 @@ void convert(std::istream& s, std::vector<unsigned char>& data, int d_offset)
 {
     // get its size:
     s.seekg(0, std::ios::end);
-    int size = s.tellg();
+    const std::streamsize size = s.tellg();
     s.seekg(0, std::ios::beg);
 
     data.resize(size + d_offset);
-    s.read((char*)&data[d_offset], size);
+    s.read(reinterpret_cast<char*>(data.data() + d_offset), size);
 }
 
 // ----------------------------------------------------------------------------------------------------
@@ -57,8 +60,8 @@ void convert(std::istream& s, std::vector<unsigned char>& data, int d_offset)
 void convert(std::vector<unsigned char>& data, Archive& a)
 {
     // Read version (int)
-    int version;
-    memcpy((char*)&(a.version_), &data[0], sizeof(version));
+    const int version = 0;
+    std::memcpy(&a.version_, data.data(), sizeof(version));
 
     // Read the rest
     convert(data, a.stream(), sizeof(version));
@@ -68,9 +71,8 @@ void convert(std::vector<unsigned char>& data, Archive& a)
 
 void convert(const std::vector<unsigned char>& data, std::ostream& s, int d_offset)
 {
-    s.write((char*)&data[d_offset], data.size() - d_offset);
+    s.write(reinterpret_cast<const char*>(data.data() + d_offset),
+            static_cast<std::streamsize>(data.size() - d_offset));
 }
 
-} // namespace serialization
-
-} // namespace tue
+} // namespace tue::serialization

--- a/tue_serialization/src/conversions.cpp
+++ b/tue_serialization/src/conversions.cpp
@@ -27,7 +27,8 @@ void convert(Archive& a, std::vector<unsigned char>& data)
 void convert(const Archive& a, std::ostream& out)
 {
     // Write the version to out
-    [[maybe_unused]] const OutputArchive a_out(out);
+    [[maybe_unused]]
+    const OutputArchive a_out(out);
 
     // Write data to out
     out << a.stream().rdbuf();

--- a/tue_serialization/src/filesystem.cpp
+++ b/tue_serialization/src/filesystem.cpp
@@ -1,12 +1,12 @@
 #include "tue/serialization/filesystem.h"
 
+#include "tue/serialization/archive.h"
 #include "tue/serialization/conversions.h"
 
 #include <fstream>
+#include <string>
 
-namespace tue
-{
-namespace serialization
+namespace tue::serialization
 {
 
 // ----------------------------------------------------------------------------------------------------
@@ -48,6 +48,4 @@ bool fromFile(const std::string& filename, Archive& a)
     return true;
 }
 
-} // namespace serialization
-
-} // namespace tue
+} // namespace tue::serialization


### PR DESCRIPTION
CI bumped clang-tidy to version 21, which flags checks the previous linter did not. Address all warnings without changing behavior:

- modernize-deprecated-headers: <string.h> -> <cstring>, std::memcpy
- modernize-concat-nested-namespaces: use namespace tue::serialization
- misc-include-cleaner: add direct includes for used symbols
- readability-container-data-pointer: &data[0] -> data.data()
- cppcoreguidelines-pro-type-cstyle-cast / google-readability-casting: C-style casts -> reinterpret_cast, drop unneeded casts to memcpy
- misc-const-correctness: mark a_out and size const
- bugprone/cppcoreguidelines-narrowing-conversions: use std::streamsize
- cppcoreguidelines-init-variables: initialize version